### PR TITLE
Lint and vet examples

### DIFF
--- a/bios.sh
+++ b/bios.sh
@@ -7,7 +7,10 @@ git reset --hard $SHA
 
 go get github.com/russross/blackfriday
 
-PKGS=$(go list $PKG/... | grep -v examples)
+PKGS=$(go list $PKG/... | grep -v examples/variables)
 run -s "Linting"  golint -set_exit_status $PKGS
+
+PKGS=$(go list $PKG/... | grep -v examples/panic)
 run -s "Vetting"  go vet -x $PKGS
+
 run -s "Building" tools/build

--- a/examples/atomic-counters/atomic-counters.go
+++ b/examples/atomic-counters/atomic-counters.go
@@ -15,7 +15,7 @@ func main() {
 
     // We'll use an unsigned integer to represent our
     // (always-positive) counter.
-    var ops uint64 = 0
+    var ops uint64
 
     // To simulate concurrent updates, we'll start 50
     // goroutines that each increment the counter about

--- a/examples/closures/closures.go
+++ b/examples/closures/closures.go
@@ -14,7 +14,7 @@ import "fmt"
 func intSeq() func() int {
     i := 0
     return func() int {
-        i += 1
+        i++
         return i
     }
 }

--- a/examples/collection-functions/collection-functions.go
+++ b/examples/collection-functions/collection-functions.go
@@ -21,7 +21,7 @@ package main
 import "strings"
 import "fmt"
 
-// Returns the first index of the target string `t`, or
+// Index returns the first index of the target string `t`, or
 // -1 if no match is found.
 func Index(vs []string, t string) int {
     for i, v := range vs {
@@ -32,13 +32,13 @@ func Index(vs []string, t string) int {
     return -1
 }
 
-// Returns `true` if the target string t is in the
+// Include returns `true` if the target string t is in the
 // slice.
 func Include(vs []string, t string) bool {
     return Index(vs, t) >= 0
 }
 
-// Returns `true` if one of the strings in the slice
+// Any returns `true` if one of the strings in the slice
 // satisfies the predicate `f`.
 func Any(vs []string, f func(string) bool) bool {
     for _, v := range vs {
@@ -49,7 +49,7 @@ func Any(vs []string, f func(string) bool) bool {
     return false
 }
 
-// Returns `true` if all of the strings in the slice
+// All returns `true` if all of the strings in the slice
 // satisfy the predicate `f`.
 func All(vs []string, f func(string) bool) bool {
     for _, v := range vs {
@@ -60,7 +60,7 @@ func All(vs []string, f func(string) bool) bool {
     return true
 }
 
-// Returns a new slice containing all strings in the
+// Filter returns a new slice containing all strings in the
 // slice that satisfy the predicate `f`.
 func Filter(vs []string, f func(string) bool) []string {
     vsf := make([]string, 0)
@@ -72,7 +72,7 @@ func Filter(vs []string, f func(string) bool) []string {
     return vsf
 }
 
-// Returns a new slice containing the results of applying
+// Map returns a new slice containing the results of applying
 // the function `f` to each string in the original slice.
 func Map(vs []string, f func(string) string) []string {
     vsm := make([]string, len(vs))

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -10,11 +10,11 @@ import "os"
 
 // We'll use these two structs to demonstrate encoding and
 // decoding of custom types below.
-type Response1 struct {
+type response1 struct {
     Page   int
     Fruits []string
 }
-type Response2 struct {
+type response2 struct {
     Page   int      `json:"page"`
     Fruits []string `json:"fruits"`
 }
@@ -50,7 +50,7 @@ func main() {
     // custom data types. It will only include exported
     // fields in the encoded output and will by default
     // use those names as the JSON keys.
-    res1D := &Response1{
+    res1D := &response1{
         Page:   1,
         Fruits: []string{"apple", "peach", "pear"}}
     res1B, _ := json.Marshal(res1D)
@@ -60,7 +60,7 @@ func main() {
     // to customize the encoded JSON key names. Check the
     // definition of `Response2` above to see an example
     // of such tags.
-    res2D := &Response2{
+    res2D := &response2{
         Page:   1,
         Fruits: []string{"apple", "peach", "pear"}}
     res2B, _ := json.Marshal(res2D)
@@ -103,7 +103,7 @@ func main() {
     // need for type assertions when accessing the decoded
     // data.
     str := `{"page": 1, "fruits": ["apple", "peach"]}`
-    res := Response2{}
+    res := response2{}
     json.Unmarshal([]byte(str), &res)
     fmt.Println(res)
     fmt.Println(res.Fruits[0])

--- a/examples/mutexes/mutexes.go
+++ b/examples/mutexes/mutexes.go
@@ -23,8 +23,8 @@ func main() {
 
     // We'll keep track of how many read and write
     // operations we do.
-    var readOps uint64 = 0
-    var writeOps uint64 = 0
+    var readOps uint64
+    var writeOps uint64
 
     // Here we start 100 goroutines to execute repeated
     // reads against the state, once per millisecond in

--- a/examples/sorting-by-functions/sorting-by-functions.go
+++ b/examples/sorting-by-functions/sorting-by-functions.go
@@ -13,7 +13,7 @@ import "fmt"
 // corresponding type. Here we've created a `ByLength`
 // type that is just an alias for the builtin `[]string`
 // type.
-type ByLength []string
+type byLength []string
 
 // We implement `sort.Interface` - `Len`, `Less`, and
 // `Swap` - on our type so we can use the `sort` package's
@@ -22,22 +22,22 @@ type ByLength []string
 // hold the actual custom sorting logic. In our case we
 // want to sort in order of increasing string length, so
 // we use `len(s[i])` and `len(s[j])` here.
-func (s ByLength) Len() int {
+func (s byLength) Len() int {
     return len(s)
 }
-func (s ByLength) Swap(i, j int) {
+func (s byLength) Swap(i, j int) {
     s[i], s[j] = s[j], s[i]
 }
-func (s ByLength) Less(i, j int) bool {
+func (s byLength) Less(i, j int) bool {
     return len(s[i]) < len(s[j])
 }
 
 // With all of this in place, we can now implement our
 // custom sort by casting the original `fruits` slice to
-// `ByLength`, and then use `sort.Sort` on that typed
+// `byLength`, and then use `sort.Sort` on that typed
 // slice.
 func main() {
     fruits := []string{"peach", "banana", "kiwi"}
-    sort.Sort(ByLength(fruits))
+    sort.Sort(byLength(fruits))
     fmt.Println(fruits)
 }

--- a/examples/stateful-goroutines/stateful-goroutines.go
+++ b/examples/stateful-goroutines/stateful-goroutines.go
@@ -37,8 +37,8 @@ type writeOp struct {
 func main() {
 
     // As before we'll count how many operations we perform.
-    var readOps uint64 = 0
-    var writeOps uint64 = 0
+    var readOps uint64
+    var writeOps uint64
 
     // The `reads` and `writes` channels will be used by
     // other goroutines to issue read and write requests,

--- a/examples/variables/variables.go
+++ b/examples/variables/variables.go
@@ -9,7 +9,7 @@ import "fmt"
 func main() {
 
     // `var` declares 1 or more variables.
-    var a string = "initial"
+    var a = "initial"
     fmt.Println(a)
 
     // You can declare multiple variables at once.


### PR DESCRIPTION
This lints and vets everything except the `variables` and `panic` examples.

I separated this PR out from #1  as changing any example content for the sake of satisfying lint or vet may not be desirable.